### PR TITLE
Update tarot.py

### DIFF
--- a/tarot/tarot.py
+++ b/tarot/tarot.py
@@ -7,8 +7,10 @@ from hoshino import util, R
 from hoshino import Service
 from hoshino.config import NICKNAME
 
-if type(NICKNAME)!=list:
-    NICKNAME=[NICKNAME]
+if type(NICKNAME) != str:
+    for NAME in NICKNAME:
+        NICKNAME = NAME
+        break
 
 cards = {
     "圣杯1": "家庭生活之幸福，别的牌可给予其更多内涵，如宾客来访、宴席、吵架",
@@ -229,7 +231,7 @@ async def chain_reply(ev, chain, msg, image):
     data ={
             "type": "node",
             "data": {
-                "name": str(NICKNAME[0]),
+                "name": str(NICKNAME),
                 "uin": str(ev.self_id),
                 "content": [
                     {"type": "text", "data": {"text": msg}},


### PR DESCRIPTION
NICKNAME类型为 _str | Iterable[str]_ ，存在多个昵称时Hoshinobot的注释推荐定义为元组，而且Nonebot文档的例子也有定义为集合的情况，原版本只考虑了列表，当上述两种情况出现时获取的昵称就会不正确，不用考虑字典因为Nonebot本身也处理不了